### PR TITLE
Move setting current time for comment

### DIFF
--- a/blablacar-service/src/main/java/cz/fi/muni/pa165/teamred/service/CommentServiceImpl.java
+++ b/blablacar-service/src/main/java/cz/fi/muni/pa165/teamred/service/CommentServiceImpl.java
@@ -5,6 +5,7 @@ import cz.fi.muni.pa165.teamred.entity.Comment;
 import org.springframework.stereotype.Service;
 
 import javax.inject.Inject;
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -15,8 +16,17 @@ public class CommentServiceImpl implements CommentService {
     @Inject
     private CommentDao commentDao;
 
+    @Inject
+    private TimeService timeService;
+
     @Override
     public Comment createComment(Comment comment) throws IllegalArgumentException {
+        if (comment == null) {
+            throw new IllegalArgumentException("Comment cannot be null.");
+        }
+
+        Date now = timeService.getCurrentTime();
+        comment.setCreated(now);
         commentDao.create(comment);
         return comment;
     }

--- a/blablacar-service/src/main/java/cz/fi/muni/pa165/teamred/service/facade/CommentFacadeImpl.java
+++ b/blablacar-service/src/main/java/cz/fi/muni/pa165/teamred/service/facade/CommentFacadeImpl.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.inject.Inject;
-import java.util.Date;
 import java.util.List;
 
 /**
@@ -32,20 +31,14 @@ public class CommentFacadeImpl implements CommentFacade {
     @Inject
     private UserService userService;
 
-    @Inject
-    private TimeService timeService;
-
     @Autowired
     private BeanMappingService beanMappingService;
 
     @Override
     public Long createComment(CommentCreateDTO commentCreateDTO) {
         Comment mappedComment = beanMappingService.mapTo(commentCreateDTO, Comment.class);
-        Date now = timeService.getCurrentTime();
-        mappedComment.setCreated(now);
-        // todo: uncomment when rideService & userService are implemented
-//        mappedComment.setRide(rideService.findById(commentCreateDTO.getRideId()));
-//        mappedComment.setAuthor(userService.findById(commentCreateDTO.getAuthorId()));
+        mappedComment.setRide(rideService.findById(commentCreateDTO.getRideId()));
+        mappedComment.setAuthor(userService.findUserById(commentCreateDTO.getAuthorId()));
         Comment comment = commentService.createComment(mappedComment);
         return comment.getId();
     }

--- a/blablacar-service/src/test/java/cz/fi/muni/pa165/teamred/service/CommentServiceTest.java
+++ b/blablacar-service/src/test/java/cz/fi/muni/pa165/teamred/service/CommentServiceTest.java
@@ -32,6 +32,9 @@ public class CommentServiceTest extends AbstractTestNGSpringContextTests {
     @Mock
     private CommentDao commentDao;
 
+    @Mock
+    private TimeService timeService;
+
     @Autowired
     @InjectMocks
     private CommentService commentService;
@@ -93,9 +96,16 @@ public class CommentServiceTest extends AbstractTestNGSpringContextTests {
     void createCommentTest() {
         doNothing().when(commentDao).create(any());
 
-        commentService.createComment(sampleComment);
+        Calendar cal = Calendar.getInstance();
+        cal.set(2015, Calendar.MARCH, 8);
+        when(timeService.getCurrentTime()).thenReturn(cal.getTime());
 
+        Comment result = commentService.createComment(sampleComment);
+
+        verify(timeService).getCurrentTime();
         verify(commentDao).create(sampleComment);
+
+        assertThat(result).isEqualToComparingFieldByField(sampleComment);
     }
 
     @Test


### PR DESCRIPTION
Setting current time for newly created comment was moved to the service layer. We need to implement 2 non-trivial cases in the service layer, this could count as one.